### PR TITLE
Update Button.ps1

### DIFF
--- a/public/Button.ps1
+++ b/public/Button.ps1
@@ -54,7 +54,8 @@ function Button {
     )
 
     begin {
-        $buttonhash = Import-PowerShellDataFile $PSScriptRoot\internal\ButtonJsonTemplate.psd1
+        $scriptPath = split-path -parent $PSScriptRoot
+        $buttonhash = Import-PowerShellDataFile $scriptPath\private\ButtonJsonTemplate.psd1
         $typehash = $buttonhash[$PSBoundParameters.ButtonType]
     }
     process {


### PR DESCRIPTION
When I run the button command I get the following error "Cannot find path 'C:\Users\dean.west\Documents\PowerShell\Modules\MsftTeams\1.0.0\public\internal\ButtonJsonTemplate.psd1' because it does not exist."

Looking at the repo internal should be private and when I run $PSScriptRoot. It automatically defined the fully-qualified filesystem path to the directory that contains the button script file. C:\Users\dean.west\Documents\PowerShell\Modules\MsftTeams\1.0.0\public

I am a novice and added the code I know fixes the issue but I do not know if it's the most efficient way to get the path.